### PR TITLE
Adds GitHub action workflow

### DIFF
--- a/.github/workflows/create-badge.yml
+++ b/.github/workflows/create-badge.yml
@@ -1,0 +1,23 @@
+name: Create Badge Action
+
+on:
+  pull_request:
+    types: [closed, labeled]
+
+jobs: 
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Actions
+        uses: actions/checkout@v2
+
+      - name: Badgr Create Badge
+        if: ${{ github.event.pull_request.merged == true }}
+        uses: yajushiSri/Badgr-Create-Badge@v1.0.0
+        id: badge
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          repo: ${{github.repository}}
+          sha: ${{github.sha}}
+          username: ${{secrets.BADGR_USERNAME}}
+          password: ${{secrets.BADGR_PASSWORD}}


### PR DESCRIPTION
Added action for automating badge distribution to contributors.
Mandatory steps for issuing a badge:

Pull request must contain relevant labels. Label 'neophyte' may be used for Badgr badge named 'THE NEOPHYTE'.
Pull request must be merged and closed.

GitHub action used: https://github.com/marketplace/actions/badgr-create-badge